### PR TITLE
Ignore error on apt timers if service does not exist

### DIFF
--- a/roles/managed_host/tasks/apt-config.yml
+++ b/roles/managed_host/tasks/apt-config.yml
@@ -12,3 +12,5 @@
   with_items:
     - apt-daily.timer
     - apt-daily-upgrade.timer
+  register: apt_timer_service_result
+  failed_when: "apt_timer_service_result is failed and 'Could not find the requested service' not in apt_timer_service_result.msg"


### PR DESCRIPTION
on older Debian versions, the apt timer service does not exist and hence we can safely ignore the error when trying to disable it 