### PR TITLE
Don't fail if there are no updates to apply

### DIFF
--- a/roles/managed_node/tasks/for-devices.yml
+++ b/roles/managed_node/tasks/for-devices.yml
@@ -31,7 +31,7 @@
 - name: apply firmware updates
   register: fwupd_update_result
   command: fwupdmgr update
-  failed_when: fwupd_update_result.rc not in [0, 2]
+  failed_when: 'fwupd_update_result.rc not in [0, 2] and "Nothing to do" not in fwupd_update_result.stdout'
   changed_when: "'Updating' in fwupd_update_result.stdout"
   when: use_fwupd and fwupd_refresh_result.changed
 


### PR DESCRIPTION
For some reason, the get firmware updates sometimes does not set the variable correctly (I did not figure out why).

In any case, this lead to the updater failing even though it stated there is nothing to do (see below). As a quick fix, I'd suggest we don't fail if this is in the output.

```
TASK [lpirl_ansible-roles/roles/managed_node : get firmware updates] *****************************************************************************************************************************
changed: [fb14srv6] => {"changed": true, "cmd": ["fwupdmgr", "refresh"], "delta": "0:00:00.798510", "end": "2020-11-02 21:55:56.945111", "failed_when_result": false, "rc": 0, "start": "2020-11-02 21:55:56.146601", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [lpirl_ansible-roles/roles/managed_node : apply firmware updates] ***************************************************************************************************************************
fatal: [fb14srv6]: FAILED! => {"changed": false, "cmd": ["fwupdmgr", "update"], "delta": "0:00:00.024199", "end": "2020-11-02 21:55:58.258669", "failed_when_result": true, "msg": "non-zero return code", "rc": 1, "start": "2020-11-02 21:55:58.234470", "stderr": "", "stderr_lines": [], "stdout": "No devices can be updated: Nothing to do", "stdout_lines": ["No devices can be updated: Nothing to do"]}
```