### PR TITLE
Compatability for older versions of sshd

### DIFF
--- a/roles/firewall/tasks/layer7.yml
+++ b/roles/firewall/tasks/layer7.yml
@@ -71,7 +71,7 @@
 
 - name: get SSH port
   register: get_ssh_port_results
-  shell: sshd -T -C user=root | grep -i '^port ' | cut -d" " -f2
+  shell: sshd -T -C user=root,host=localhost,addr=localhost | grep -i '^port ' | cut -d" " -f2
   changed_when: false
 
 - name: set SSH port for fail2ban


### PR DESCRIPTION
In older versions of `sshd`, next to user, the host and addr parameters are also required.

Could you please double-check if specifying localhost here makes sense? I am not too sure what this does (by skimming the man page, I think this simulates a ssh connection), so I would be thankful if you could confirm this is a good choice. 